### PR TITLE
Offer pre-built files in a 'build' branch.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
         run: |
           rm -rf source/wp-content/plugins/wporg-internal-notes/src
           rm -rf source/wp-content/plugins/wporg-internal-notes/node_modules
+          rm -rf source/wp-content/plugins/wporg-internal-notes/package.json
 
-      - name: Create package.json
+      - name: Create composer.json
         run: |
-          cd source/wp-content/plugins/wporg-internal-notes/
-          cat <<<$( jq '{ name, version, description, author, homepage, license, support }' package.json ) > package.json
+          jq '{ name, version, description, author, homepage, license, support }' composer.json > source/wp-content/plugins/wporg-internal-notes/composer.json
 
       - name: Push
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,15 @@ jobs:
       - name: Build
         run: yarn workspaces run build
 
-      # Got to be a better way than this, but it works.
       - name: Remove Source files
         run: |
           rm -rf source/wp-content/plugins/wporg-internal-notes/src
           rm -rf source/wp-content/plugins/wporg-internal-notes/node_modules
+
+      - name: Create package.json
+        run: |
+          cd source/wp-content/plugins/wporg-internal-notes/
+          cat <<<$( jq '{ name, version, description, author, homepage, license, support }' package.json ) > package.json
 
       - name: Push
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create composer.json
         run: |
-          jq '{ name, version, description, author, homepage, license, support }' composer.json > source/wp-content/plugins/wporg-internal-notes/composer.json
+          jq '{ name, description, homepage, license, support }' composer.json > source/wp-content/plugins/wporg-internal-notes/composer.json
 
       - name: Push
         uses: s0/git-publish-subdir-action@develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Update the build branch
+
+on:
+  push:
+    branches: [ 'trunk' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build and push to branch
+    steps:
+      - name: git-checkout
+        uses: actions/checkout@v2
+
+      - name: Install all dependencies
+        run: yarn run initial-setup
+
+      - name: Build
+        run: yarn workspaces run build
+
+      # Got to be a better way than this, but it works.
+      - name: Remove Source files
+        run: |
+          rm -rf source/wp-content/plugins/wporg-internal-notes/src
+          rm -rf source/wp-content/plugins/wporg-internal-notes/node_modules
+
+      - name: Push
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: build
+          FOLDER: source/wp-content/plugins/wporg-internal-notes
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MESSAGE: "Build: ({sha}) {msg}"

--- a/source/wp-content/plugins/wporg-internal-notes/package.json
+++ b/source/wp-content/plugins/wporg-internal-notes/package.json
@@ -3,8 +3,12 @@
 	"version": "1.0.0",
 	"description": "Enables adding internal notes to supporting post types on WordPress.org",
 	"author": "WordPress.org",
+	"homepage": "https://wordpress.org",
 	"license": "GPL-2.0-or-later",
 	"private": true,
+	"support": {
+		"issues": "https://github.com/WordPress/wporg-internal-notes/issues"
+	},
 	"dependencies": {},
 	"devDependencies": {
 		"@wordpress/browserslist-config": "^4.1.0",

--- a/source/wp-content/plugins/wporg-internal-notes/package.json
+++ b/source/wp-content/plugins/wporg-internal-notes/package.json
@@ -3,12 +3,8 @@
 	"version": "1.0.0",
 	"description": "Enables adding internal notes to supporting post types on WordPress.org",
 	"author": "WordPress.org",
-	"homepage": "https://wordpress.org",
 	"license": "GPL-2.0-or-later",
 	"private": true,
-	"support": {
-		"issues": "https://github.com/WordPress/wporg-internal-notes/issues"
-	},
 	"dependencies": {},
 	"devDependencies": {
 		"@wordpress/browserslist-config": "^4.1.0",


### PR DESCRIPTION
I was attempting to use this plugin on another site and pull from a public location.

Unfortunately built files are not included, so I've added a github action to build them.

This allows me to run `git clone git@github.com:WordPress/wporg-internal-notes.git --branch build` to immediately have it available.

I'm unsure of if there's anything that would need to do to make this usable as a composer plugin dependancy, but others will have more of an idea on that.