### PR TITLE
Make author data more versatile

### DIFF
--- a/source/wp-content/plugins/wporg-internal-notes/includes/class-rest-controller.php
+++ b/source/wp-content/plugins/wporg-internal-notes/includes/class-rest-controller.php
@@ -37,7 +37,7 @@ class REST_Controller extends \WP_REST_Controller {
 	 * @param string $parent_post_type Post type of the parent.
 	 */
 	public function __construct( $parent_post_type ) {
-		$this->namespace = 'wp/v2';
+		$this->namespace = 'wporg/v1';
 		$this->rest_base = 'internal-notes';
 
 		$post_type_object = get_post_type_object( $parent_post_type );
@@ -356,7 +356,7 @@ class REST_Controller extends \WP_REST_Controller {
 
 		$response->add_link(
 			'author',
-			rest_url( sprintf( '%s/%s/%d', $this->namespace, 'users', $data['author'] ) ),
+			rest_url( sprintf( 'wp/v2/users/%d', $data['author'] ) ),
 			array(
 				'embeddable' => true,
 			)

--- a/source/wp-content/plugins/wporg-internal-notes/src/notes-list/notes-list-item.js
+++ b/source/wp-content/plugins/wporg-internal-notes/src/notes-list/notes-list-item.js
@@ -76,6 +76,8 @@ export const NotesListItem = ( { className, note } ) => {
 	const author = note?._embedded?.author?.[ 0 ];
 	const avatarUrl = author?.avatar_urls?.[ '24' ] || '';
 	const slug = author?.slug || 'unknown';
+	const handle = sprintf( '@%s', slug );
+	const link = author?.link || '';
 
 	const excerpt = note?.excerpt?.rendered;
 	const { isCreated, isDeleted } = useSelect(
@@ -117,14 +119,21 @@ export const NotesListItem = ( { className, note } ) => {
 					<time className="wporg-internal-notes__note-date" title={ dateIso } dateTime={ dateIso }>
 						{ dateRelative }
 					</time>
-					<a
-						className="wporg-internal-notes__note-author-name"
-						href={ sprintf( 'https://profiles.wordpress.org/%s', slug ) }
-						target="_blank"
-						rel="noreferrer"
-					>
-						{ sprintf( '@%s', slug ) }
-					</a>
+					{ link &&
+						<a
+							className="wporg-internal-notes__note-author-name"
+							href={ link }
+							target="_blank"
+							rel="noreferrer"
+						>
+							{ handle }
+						</a>
+					}
+					{ ! link &&
+						<span className="wporg-internal-notes__note-author-name">
+							{ handle }
+						</span>
+					}
 				</footer>
 			</li>
 		);
@@ -137,14 +146,21 @@ export const NotesListItem = ( { className, note } ) => {
 					{ avatarUrl && (
 						<img className="wporg-internal-notes__note-author-avatar" src={ avatarUrl } alt="" />
 					) }
-					<a
-						className="wporg-internal-notes__note-author-name"
-						href={ sprintf( 'https://profiles.wordpress.org/%s', slug ) }
-						target="_blank"
-						rel="noreferrer"
-					>
-						{ sprintf( '@%s', slug ) }
-					</a>
+					{ link &&
+						<a
+							className="wporg-internal-notes__note-author-name"
+							href={ link }
+							target="_blank"
+							rel="noreferrer"
+						>
+							{ handle }
+						</a>
+					}
+					{ ! link &&
+						<span className="wporg-internal-notes__note-author-name">
+							{ handle }
+						</span>
+					}
 				</div>
 				<DeleteButton noteId={ noteId } />
 			</header>

--- a/source/wp-content/plugins/wporg-internal-notes/src/store/utils.js
+++ b/source/wp-content/plugins/wporg-internal-notes/src/store/utils.js
@@ -10,7 +10,7 @@ export const getApiPath = ( { noteId, queryArgs = [] } ) => {
 	const postType = select( 'core/editor' ).getCurrentPostType();
 	const { rest_base: restBase } = select( 'core' ).getPostType( postType );
 
-	let path = `/wp/v2/${ restBase }/${ postId }/internal-notes`;
+	let path = `/wporg/v1/${ restBase }/${ postId }/internal-notes`;
 	if ( noteId ) {
 		path += `/${ noteId }`;
 	}


### PR DESCRIPTION
This replaces the hardcoded wporg profile URL of the note author with the API reponse's `link` property. The reasoning is that there might be a context for this plugin where using the profiles URL doesn't make sense, so the generic author URL should be the default. The link can be changed back to the profiles URL (or anything else), and even used for embedded data, via the filter that was [just added](https://github.com/WordPress/wporg-internal-notes/commit/f88006fed9053c3538623525f4b31682fc14ec14).

This also changes the namespace of this plugin's REST API endpoint to `wporg/v1` to better differentiate it from Core endpoints.