### PR TITLE
Support notes with HTML tags.

### DIFF
--- a/source/wp-content/plugins/wporg-internal-notes/includes/class-rest-controller.php
+++ b/source/wp-content/plugins/wporg-internal-notes/includes/class-rest-controller.php
@@ -288,9 +288,11 @@ class REST_Controller extends \WP_REST_Controller {
 
 		$excerpt = false;
 		if ( isset( $request['excerpt'] ) && is_string( $request['excerpt'] ) ) {
-			$excerpt = sanitize_textarea_field( $request['excerpt'] );
+			$excerpt = esc_html( $request['excerpt'] );
+			$excerpt = sanitize_textarea_field( $excerpt );
 		} elseif ( isset( $request['excerpt']['raw'] ) && is_string( $request['excerpt']['raw'] ) ) {
-			$excerpt = sanitize_textarea_field( $request['excerpt']['raw'] );
+			$excerpt = esc_html( $request['excerpt']['raw'] );
+			$excerpt = sanitize_textarea_field( $excerpt );
 		}
 
 		if ( ! $excerpt ) {


### PR DESCRIPTION
Currently when you add a note which contains HTML, it gets stripped out of the note.

This appears to be expected, due to the usage of `sanitize_textarea_field()` which strips HTML.

It's unexpected that when you're adding a comment such as `They added a <strong> tag` that the text is stripped out.

This PR simply HTML escapes the content first, before applying the textarea cleanups during note creation.